### PR TITLE
(maint) Catch everything in query middleware

### DIFF
--- a/src/puppetlabs/puppetdb/middleware.clj
+++ b/src/puppetlabs/puppetdb/middleware.clj
@@ -117,6 +117,14 @@
       (catch Exception e
         (log/error e)
         (http/error-response (cause-finder e)
+                             http/status-internal-error))
+     (catch AssertionError e
+        (log/error e)
+        (http/error-response (tru "An unexpected error occurred while processing the request")
+                             http/status-internal-error))
+     (catch Throwable e
+        (log/error e)
+        (http/error-response (tru "An unexpected error occurred")
                              http/status-internal-error)))))
 
 (defn verify-accepts-content-type


### PR DESCRIPTION
In order to safely `assert` things in the query code, we need to ensure
that we do not leak AssertionErrors, which are not caught by `catch
Exception`. Add catch Throwable as a catch-all backstop to
any other thing that could be thrown.